### PR TITLE
Add more settings for fbalpha core

### DIFF
--- a/game.libretro.fbalpha/resources/language/English/strings.po
+++ b/game.libretro.fbalpha/resources/language/English/strings.po
@@ -61,5 +61,5 @@ msgid "Diagnostic Input"
 msgstr ""
 
 msgctxt "#30011"
-msgid "fba-vertical-mode"
+msgid "Vertical mode"
 msgstr ""

--- a/game.libretro.fbalpha/resources/language/English/strings.po
+++ b/game.libretro.fbalpha/resources/language/English/strings.po
@@ -52,3 +52,14 @@ msgctxt "#30008"
 msgid "Psikyo/Kaneko SH2 mode (need 'hard' restart)"
 msgstr ""
 
+msgctxt "#30009"
+msgid "Force Neo Geo mode (if available)"
+msgstr ""
+
+msgctxt "#30010"
+msgid "Diagnostic Input"
+msgstr ""
+
+msgctxt "#30011"
+msgid "fba-vertical-mode"
+msgstr ""

--- a/game.libretro.fbalpha/resources/settings.xml
+++ b/game.libretro.fbalpha/resources/settings.xml
@@ -9,5 +9,8 @@
 		<setting label="30006" type="select" id="fba-lr-controls-p1" values="normal|remap to R1/R2" default="normal"/>
 		<setting label="30007" type="select" id="fba-lr-controls-p2" values="normal|remap to R1/R2" default="normal"/>
 		<setting label="30008" type="select" id="fba-sh2-mode" values="accurate|fast" default="accurate"/>
+		<setting label="30009" type="select" id="fba-neogeo-mode" values="MVS|AES|UNIBIOS|DIPSWITCH" default="MVS"/>
+		<setting label="30010" type="select" id="fba-diagnostic-input" values="None|Hold Start|Start + A + B|Hold Start + A + B|Start + L + R|Hold Start + L + R|Hold Select|Select + A + B|Hold Select + A + B|Select + L + R|Hold Select + L + R" default="None"/>
+		<setting label="30011" type="select" id="fba-vertical-mode" values="disabled|enabled" default="disabled"/>
 	</category>
 </settings>


### PR DESCRIPTION
In retroarch the option for neo-geo appeared just for neogeo game. 
I don't know how to hide it in retroplayer.
Maybe it will not impact not neo-geo games if this option is present.
Thanks,